### PR TITLE
Update path for Windows release version

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -27,7 +27,7 @@ module.exports = {
             "d": path.join(home, "Library", "Application Support", "Adobe", "Adobe XD CC (Dev)")
         },
         "win": {
-            "r": path.join(home, "AppData", "Local", "Packages", "Adobe.CC.XD.adky2gkssdxte", "LocalState"),
+            "r": path.join(home, "AppData", "Local", "Packages", "Adobe.CC.XD_adky2gkssdxte", "LocalState"),
             "p": path.join(home, "AppData", "Local", "Packages", "Adobe.CC.XD.Prerelease_adky2gkssdxte", "LocalState"),
             "d": path.join(home, "AppData", "Local", "Packages", "Adobe.CC.XD.Dev_adky2gkssdxte", "LocalState")
         }


### PR DESCRIPTION
fixes #5 – corrects a wrong Adobe XD folder path for the release version on Windows (before, `xdpm install` and similar outputted an error message: `ERROR: Could not locate C:\Users\pablo\AppData\Local\Packages\Adobe.CC.XD.adky2gkssdxte\LocalState. Do you have the release version of Adobe XD CC installed?`).