### PR TITLE
Update constants to point to new path on macOS for XD 18

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -22,9 +22,9 @@ const home = os.homedir();
 module.exports = {
     FOLDERS: {
         "mac": {
-            "r": path.join(home, "Library", "Application Support", "Adobe", "Adobe XD CC"),
-            "p": path.join(home, "Library", "Application Support", "Adobe", "Adobe XD CC (Prerelease)"),
-            "d": path.join(home, "Library", "Application Support", "Adobe", "Adobe XD CC (Dev)")
+            "r": path.join(home, "Library", "Application Support", "Adobe", "Adobe XD"),
+            "p": path.join(home, "Library", "Application Support", "Adobe", "Adobe XD (Prerelease)"),
+            "d": path.join(home, "Library", "Application Support", "Adobe", "Adobe XD (Dev)")
         },
         "win": {
             "r": path.join(home, "AppData", "Local", "Packages", "Adobe.CC.XD_adky2gkssdxte", "LocalState"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/xdpm",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Adobe XD CLI Plugin Manager Utility",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Considering this a breaking change, since this will NOT work with older versions of XD.