### PR TITLE
Nonzero val err

### DIFF
--- a/commands/validate.js
+++ b/commands/validate.js
@@ -34,7 +34,7 @@ function validatePlugin(opts, args) {
     const errors = reportResults(opts, results);
 
     if (errors) {
-        shell.echo(`Error: manifest validation failed. Exiting with code ${validateErrCode}`);
+        cli.error(`Manifest validation failed. Exiting with code ${validateErrCode}`);
         shell.exit(validateErrCode);
     }
     else {        
@@ -70,6 +70,12 @@ function getResults(args) {
     return results;
 }
 
+/**
+ * Prints validation results for each tested plugin to command line.
+ * @param {*} opts 
+ * @param {*} results 
+ * @returns {boolean} True if there was an error for any of the tested plugin manifests.
+ */
 function reportResults(opts, results) {
     if (opts.json) {
         shell.echo(JSON.stringify(results));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

xdpm exits with non-zero value if manifest validation fails. See related discussion in #32 

Looking for discussion on this implementation. I'm currently considering rolling this into xdpm 4.0 along with #31, but let's see if more detailed discussion is required.

## Related Issue

Addresses #32: fail validation with error code.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

I'm calling this a breaking change because it may break any existing instrumentation surrounding xdpm if you were expecting exit code 0 when validation failure occurs.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
