### PR TITLE
CI for xdpm with GitHub actions

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -19,3 +19,9 @@ jobs:
     - run: npm install
     - run: npm link
     - run: xdpm -v
+    - run: xdpm validate
+      continue-on-error: true
+    - run: xdpm package
+      continue-on-error: true
+    - run: xdpm install
+      continue-on-error: true

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -26,5 +26,5 @@ jobs:
     - run: xdpm install
       continue-on-error: true
     - run: git clone https://github.com/AdobeXD/plugin-samples.git
-    - run: cd plugin-samples/quick-start
     - run: xdpm validate
+      working-directory: ./plugin-samples/quick-start

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -25,3 +25,6 @@ jobs:
       continue-on-error: true
     - run: xdpm install
       continue-on-error: true
+    - run: git clone https://github.com/AdobeXD/plugin-samples.git
+    - run: cd plugin-samples/quick-start
+    - run: xdpm validate

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -1,0 +1,21 @@
+name: xdpm CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm link
+    - run: xdpm -v

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -28,3 +28,10 @@ jobs:
     - run: git clone https://github.com/AdobeXD/plugin-samples.git
     - run: xdpm validate
       working-directory: ./plugin-samples/quick-start
+    - run: xdpm package
+      working-directory: ./plugin-samples/quick-start
+    - run: echo "{}" > ./manifest.json
+      working-directory: ./plugin-samples/quick-start
+    - run: xdpm validate
+      working-directory: ./plugin-samples/quick-start
+      continue-on-error: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a GitHub actions workflow to add some basic CI, meaning Code Review etc. no longer needs everyone to pull the current changes, but just requires looking at the output of the CI.

Currently, I haven't found a way to let the test fail when something that should fail passes (e.g., if `xdpm validate` passed while outside a plugin dir), but it is a first step into the right direction; I'm more than open for input on how better CI could get achieved for such a CLI.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This somewhat relates to current other PRs where I've been doing QA. Always having to clone the project to check output is kind of annoying and slows down the review process by a lot, but this doesn't necessarily fix any particular issues.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->



## How Has This Been Tested?

This is a test by itself. Testing tests would get kind of Meta (who would test this next level of tests, after all), so I've manually tried it :stuck_out_tongue_winking_eye: . It is, however, not really functional, meaning it only is required to be a valid GH Actions workflow...

## Screenshots (if appropriate):
n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (Meta)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation **(maybe?)**.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes (?).
- [x] All new and existing tests passed.
