### PR TITLE
feat: Added ignoreFiles option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Commands:
   install                Install a plugin in development mode
   ls                     List all plugins in development mode
   package                Package a plugin
-  validate               Validate a plugin\'s manifest
+  validate               Validate a plugin's manifest
   watch                  Watch a plugin directory. If no directory is
                          specified, `.` is assumed
 ```

--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ Plugin type options:
 ## Installing a plugin
 
 ```shell
-xdpm install                            # Install the current folder into Adobe XD
-xdpm install path/to/plugin             # Install the specified folder into Adobe XD
-xdpm install -w release                 # Install to Adobe XD CC Release (`r` is also valid; default)
-xdpm install -w prerelease              # Install to Adobe XD CC Prerelease (`p` is also valid)
-xdpm install -o                         # Overwrite plugin if it exists
-xdpm install -c                         # Install cleanly (remove existing)
+xdpm install                                                    # Install the current folder into Adobe XD
+xdpm install path/to/plugin                                     # Install the specified folder into Adobe XD
+xdpm install -w release                                         # Install to Adobe XD CC Release (`r` is also valid; default)
+xdpm install -w prerelease                                      # Install to Adobe XD CC Prerelease (`p` is also valid)
+xdpm install -o                                                 # Overwrite plugin if it exists
+xdpm install -c                                                 # Install cleanly (remove existing)
+xdpm install --ignore-files ".xdignore, .npmignore"             # Override default list of .*ignore files ".gitignore, .xdignore, .npmignore"
 ```
 
 You can install a plugin folder into Adobe XD using `xdpm install [...folders]`. If you don't specify a folder `xdpm install` assumes your current directory is a plugin and will install it into Adobe XD.
@@ -58,11 +59,12 @@ If the plugin folder is not a valid XD plugin, you'll receive an error upon atte
 ## Watching a plugin
 
 ```shell
-xdpm watch                            # Watch current folder and install changes into Adobe XD
-xdpm watch path/to/plugin             # Watch the specified folder and install changes into Adobe XD
-xdpm watch -w release                 # Install to Adobe XD CC Release (`r` is also valid; default)
-xdpm watch -w prerelease              # Install to Adobe XD CC Prerelease (`p` is also valid)
-xdpm watch -c                         # Perform clean installs when watching
+xdpm watch                                                      # Watch current folder and install changes into Adobe XD
+xdpm watch path/to/plugin                                       # Watch the specified folder and install changes into Adobe XD
+xdpm watch -w release                                           # Install to Adobe XD CC Release (`r` is also valid; default)
+xdpm watch -w prerelease                                        # Install to Adobe XD CC Prerelease (`p` is also valid)
+xdpm watch -c                                                   # Perform clean installs when watching
+xdpm watch --ignore-files ".xdignore, .npmignore"               # Override default list of .*ignore files ".gitignore, .xdignore, .npmignore"
 ```
 
 When developing a plugin, you can work directly in Adobe XD's `develop` folder, but this may not fit your particular workflow. In this case, you can invoke `xdpm watch` on a folder (or the current directory) and whenever changes are made, `xdpm install` will be automatically invoked to reinstall the plugins. This can simplify your development process significantly, especially if you don't use a build process.
@@ -111,13 +113,14 @@ Options:
                          [r|p|d|release|pre|prerelease|dev|development]  (Default is r)
   -k, --no-color         Omit color from output
       --debug            Show debug information
+      --ignore-files     Provide a custom list of .*ignore files, to override default ".gitignore, .xdignore, .npmignore"
   -h, --help             Display help and usage details
 
 Commands:
   install                Install a plugin in development mode
   ls                     List all plugins in development mode
   package                Package a plugin
-  validate               Validate a plugin's manifest
+  validate               Validate a plugin\'s manifest
   watch                  Watch a plugin directory. If no directory is
                          specified, `.` is assumed
 ```

--- a/commands/install.js
+++ b/commands/install.js
@@ -83,14 +83,11 @@ function install(opts, args) {
             ignoreFiles: [".gitignore", ".xdignore", ".npmignore"],
             includeEmpty: false,
         }
-        if (opts.ignoreFiles) {
-          const ignoreFilesOpt = opts.ignoreFiles
-            .split(/,|\s/)
-            .map((f) => f.trim())
-            .filter(Boolean);
-
-          walkConfig.ignoreFiles =
-            (ignoreFilesOpt && ignoreFilesOpt.length) || walkConfig.ignoreFiles;
+        if (opts.ignoreFiles !== null) {
+            walkConfig.ignoreFiles = opts.ignoreFiles
+                .split(/,|\s/)
+                .map((f) => f.trim())
+                .filter(Boolean);
         }
 
         const files = ignoreWalk

--- a/commands/install.js
+++ b/commands/install.js
@@ -73,16 +73,29 @@ function install(opts, args) {
         } else {
             shell.mkdir(targetFolder);
         }
-
+        
         // the comment below doesn't respect .xdignore (or other ignore files)
         // but this is the gist of what we're trying to accomplish
         // shell.cp("-R", path.join(sourcePath, "*"), targetFolder)
 
-        const files = ignoreWalk.sync({
+        const walkConfig = {
             path: sourcePath,
             ignoreFiles: [".gitignore", ".xdignore", ".npmignore"],
             includeEmpty: false,
-        }).filter(filterAlwaysIgnoredFile);
+        }
+        if (opts.ignoreFiles) {
+          const ignoreFilesOpt = opts.ignoreFiles
+            .split(/,|\s/)
+            .map((f) => f.trim())
+            .filter(Boolean);
+
+          walkConfig.ignoreFiles =
+            (ignoreFilesOpt && ignoreFilesOpt.length) || walkConfig.ignoreFiles;
+        }
+
+        const files = ignoreWalk
+          .sync(walkConfig)
+          .filter(filterAlwaysIgnoredFile);
 
         files.forEach(file => {
             const srcFile = path.join(sourcePath, file);

--- a/index.js
+++ b/index.js
@@ -51,6 +51,9 @@ const options = {
     "Which Adobe XD instance to target",
     ["r", "p", "d", "release", "pre", "prerelease", "dev", "development"],
     "r"
+  ],
+  ignoreFiles: [
+    "ignore-files", "List of .*ignore files to proceed. Default is \".gitignore, .xdignore, .npmignore\"", 'string'
   ]
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding an option to pass extra list of .*ignore files to install command, to get more flexibility to end user:

```sh
xdpm install --ignore-files ".gitignore, .xdignore, .npmignore"
```

More details in related issue #38 

## Related Issue

#38 

## Motivation and Context

Described in related issue #38 

## How Has This Been Tested?

Manually on Windows, but I believe there is no cross-platform issues.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
